### PR TITLE
fix: add `on:click` event to the `NavBar` authentication

### DIFF
--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -15,13 +15,16 @@
   flex="flex-1 lg:flex-none justify-center"
   rounded=""
   border=""
-  class="bg-surface-100-800-token hidden h-full md:block ">
+  class="bg-surface-100-800-token hidden h-full md:block">
   {#each links as link (link.name)}
-    <TabAnchor href={link.href} selected={$page.url.pathname === link.href}>
-      <svelte:fragment slot="lead"
-        ><div class="flex justify-center">
+    <TabAnchor
+      on:click={() => (window.location.href = link.href)}
+      selected={$page.url.pathname === link.href}>
+      <svelte:fragment slot="lead">
+        <div class="flex justify-center">
           <svelte:component this={link.icon} />
-        </div></svelte:fragment>
+        </div>
+      </svelte:fragment>
       <span>{link.name}</span>
     </TabAnchor>
   {/each}


### PR DESCRIPTION
### 🛠 Proposed Changes:

`"src/lib/components/NavBar.svelte"` uses a mouse event instead of directly changing the `href`.

### 📝 Details:

`"src/lib/components/NavBar.svelte"`: the TabAnchor tag uses the `on:click={...}` mouse event rather than `href={href.link}`

### 🔗 Related Issue(s):

Direct continuation of the `fix/authentication-chatbot-review` branch [pull request](https://github.com/SvelteShipSolutions/SvelteShip-SOEN-343/pull/34)
